### PR TITLE
feat(network-activity-plugin): add "copy as cURL" button

### DIFF
--- a/packages/network-activity-plugin/src/react-native/network-inspector.ts
+++ b/packages/network-activity-plugin/src/react-native/network-inspector.ts
@@ -1,4 +1,4 @@
-import { NetworkActivityDevToolsClient } from '../shared/client';
+import { NetworkActivityDevToolsClient, RequestPostData } from '../shared/client';
 import { getHttpHeaderValue } from '../ui/utils/getHttpHeaderValue';
 import { getNetworkRequestsRegistry } from './network-requests-registry';
 import { XHRInterceptor } from './xhr-interceptor';
@@ -113,7 +113,7 @@ export const getNetworkInspector = (
     return `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
   };
 
-  const handleRequestSend = (data: string, request: XMLHttpRequest): void => {
+  const handleRequestSend = (data: RequestPostData, request: XMLHttpRequest): void => {
     const sendTime = Date.now();
 
     const requestId = generateRequestId();

--- a/packages/network-activity-plugin/src/react-native/xhr-interceptor.ts
+++ b/packages/network-activity-plugin/src/react-native/xhr-interceptor.ts
@@ -1,5 +1,7 @@
 /* eslint-disable prefer-rest-params */
 
+import { RequestPostData } from "../shared/client";
+
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -20,7 +22,7 @@ type XHRInterceptorOpenCallback = (
 ) => void;
 
 type XHRInterceptorSendCallback = (
-  data: string,
+  data: RequestPostData,
   request: XMLHttpRequest
 ) => void;
 
@@ -136,7 +138,7 @@ export const XHRInterceptor = {
     // register listeners to intercept the response, and invoke the callbacks.
     // $FlowFixMe[cannot-write]
     // $FlowFixMe[missing-this-annot]
-    XMLHttpRequest.prototype.send = function (data: string) {
+    XMLHttpRequest.prototype.send = function (data: RequestPostData) {
       if (sendCallback) {
         sendCallback(data, this);
       }

--- a/packages/network-activity-plugin/src/shared/client.ts
+++ b/packages/network-activity-plugin/src/shared/client.ts
@@ -5,11 +5,19 @@ export type HttpHeaders = Record<string, string>;
 export type RequestId = string;
 export type Timestamp = number;
 
+export type ReactNativeFormData = { _parts: [string, string | number | boolean | null][] };
+
+export type RequestPostData = 
+  | string
+  | object // Usually it is FormData in specific react-native format, but let's accept any object
+  | null 
+  | undefined;
+
 export type Request = {
   url: string;
   method: string;
   headers: HttpHeaders;
-  postData?: string;
+  postData?: RequestPostData;
 };
 
 export type Response = {

--- a/packages/network-activity-plugin/src/ui/components/Button.tsx
+++ b/packages/network-activity-plugin/src/ui/components/Button.tsx
@@ -21,6 +21,7 @@ const buttonVariants = cva(
       },
       size: {
         default: 'h-10 px-4 py-2',
+        xs: 'h-7 rounded-md px-2 text-xs',
         sm: 'h-9 rounded-md px-3',
         lg: 'h-11 rounded-md px-8',
         icon: 'h-10 w-10',

--- a/packages/network-activity-plugin/src/ui/components/CopyAsCurlButton.tsx
+++ b/packages/network-activity-plugin/src/ui/components/CopyAsCurlButton.tsx
@@ -17,7 +17,7 @@ export const CopyAsCurlButton = ({ selectedRequest }: CopyAsCurlButtonProps) => 
     const curlCommand = generateCurlCommand({
       method: selectedRequest.method,
       url: `${selectedRequest.domain}${selectedRequest.path}`,
-      headers: selectedRequest.headers,
+      headers: selectedRequest.requestHeaders,
       postData: selectedRequest.requestBody?.data,
     });
 

--- a/packages/network-activity-plugin/src/ui/components/CopyAsCurlButton.tsx
+++ b/packages/network-activity-plugin/src/ui/components/CopyAsCurlButton.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+import { Button } from './Button';
+import { generateCurlCommand } from '../utils/generateCurlCommand';
+import { copyToClipboard } from '../utils/copyToClipboard';
+import { NetworkRequest } from './RequestList';
+
+export type CopyAsCurlButtonProps = {
+  selectedRequest?: NetworkRequest;
+};
+
+export const CopyAsCurlButton = ({ selectedRequest }: CopyAsCurlButtonProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), [])
+
+  const handleCopyCurl = async () => {
+    if (!selectedRequest) return;
+
+    try {
+      const curlCommand = generateCurlCommand({
+        method: selectedRequest.method,
+        url: `${selectedRequest.domain}${selectedRequest.path}`,
+        headers: selectedRequest.headers,
+        postData: selectedRequest.requestBody?.data,
+      });
+
+      await copyToClipboard(curlCommand);
+      
+      setCopied(true);
+
+      clearTimeout(timeoutRef.current);
+
+      timeoutRef.current = setTimeout(() => setCopied(false), 1000);
+    } catch (error) {
+      console.error('Failed to copy cURL command:', error);
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="xs"
+      onClick={handleCopyCurl}
+      disabled={!selectedRequest}
+      className="border border-gray-700"
+    >
+      {copied ? <Check className="w-2 h-2" /> : <Copy className="w-2 h-2" />}
+      Copy as cURL
+    </Button>
+  );
+};

--- a/packages/network-activity-plugin/src/ui/components/RequestList.tsx
+++ b/packages/network-activity-plugin/src/ui/components/RequestList.tsx
@@ -8,7 +8,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { NetworkEntry } from '../types';
-import { RequestId } from '../../shared/client';
+import { RequestPostData, RequestId } from '../../shared/client';
 import { getHttpHeaderValue } from '../utils/getHttpHeaderValue';
 
 type NetworkRequest = {
@@ -25,13 +25,14 @@ type NetworkRequest = {
   startTime: string;
   requestBody?: {
     type: string;
-    data: string;
+    data: RequestPostData;
   };
   responseBody?: {
     type: string;
     data: string | null;
   };
-  headers?: Record<string, string>;
+  requestHeaders?: Record<string, string>;
+  responseHeaders?: Record<string, string>;
 };
 
 type RequestListProps = {
@@ -205,7 +206,8 @@ const processNetworkEntries = (
       type: mapResourceType(entry.type || 'Other'),
       initiator: formatInitiator(entry.initiator),
       startTime: formatStartTime(entry.startTime || 0),
-      headers: entry.request?.headers,
+      requestHeaders: entry.request?.headers,
+      responseHeaders: entry.response?.headers,
       requestBody: entry.request?.postData
         ? {
             type: getHttpHeaderValue(entry.request.headers, 'content-type') || 'text/plain',

--- a/packages/network-activity-plugin/src/ui/components/RequestList.tsx
+++ b/packages/network-activity-plugin/src/ui/components/RequestList.tsx
@@ -31,6 +31,7 @@ type NetworkRequest = {
     type: string;
     data: string | null;
   };
+  headers?: Record<string, string>;
 };
 
 type RequestListProps = {
@@ -204,6 +205,7 @@ const processNetworkEntries = (
       type: mapResourceType(entry.type || 'Other'),
       initiator: formatInitiator(entry.initiator),
       startTime: formatStartTime(entry.startTime || 0),
+      headers: entry.request?.headers,
       requestBody: entry.request?.postData
         ? {
             type: getHttpHeaderValue(entry.request.headers, 'content-type') || 'text/plain',

--- a/packages/network-activity-plugin/src/ui/hooks/useCopyToClipboard.ts
+++ b/packages/network-activity-plugin/src/ui/hooks/useCopyToClipboard.ts
@@ -1,0 +1,28 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+import { copyToClipboard } from '../utils/copyToClipboard';
+
+export function useCopyToClipboard() {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
+
+  const copy = useCallback(async (value: string) => {
+    try {
+      await copyToClipboard(value);
+  
+      setIsCopied(true);
+  
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setIsCopied(false), 1000);
+    } catch (error) {
+      console.error('Failed to copy:', error);
+    }
+  }, []);
+
+  return { isCopied, copy };
+}

--- a/packages/network-activity-plugin/src/ui/tabs/HeadersTab.tsx
+++ b/packages/network-activity-plugin/src/ui/tabs/HeadersTab.tsx
@@ -52,7 +52,7 @@ export const HeadersTab = ({
           </h4>
           <div className="space-y-1 text-sm font-mono">
             {(() => {
-              const responseHeaders = selectedRequest.headers;
+              const responseHeaders = selectedRequest.responseHeaders;
               if (responseHeaders && Object.keys(responseHeaders).length > 0) {
                 return Object.entries(responseHeaders).map(([key, value]) => (
                   <div key={key} className="flex">
@@ -79,7 +79,7 @@ export const HeadersTab = ({
           </h4>
           <div className="space-y-1 text-sm font-mono">
             {(() => {
-              const requestHeaders = selectedRequest.headers;
+              const requestHeaders = selectedRequest.requestHeaders;
               if (requestHeaders && Object.keys(requestHeaders).length > 0) {
                 return Object.entries(requestHeaders).map(([key, value]) => (
                   <div key={key} className="flex">

--- a/packages/network-activity-plugin/src/ui/tabs/HeadersTab.tsx
+++ b/packages/network-activity-plugin/src/ui/tabs/HeadersTab.tsx
@@ -1,30 +1,20 @@
+import { CopyAsCurlButton } from '../components/CopyAsCurlButton';
+import { NetworkRequest } from '../components/RequestList';
 import { ScrollArea } from '../components/ScrollArea';
-import { NetworkEntry } from '../types';
 
 export type HeadersTabProps = {
-  selectedRequest: {
-    id: string;
-    domain: string;
-    path: string;
-    method: string;
-    status: number;
-    requestBody?: {
-      type: string;
-      data: string;
-    };
-  };
-  networkEntries: Map<string, NetworkEntry>;
+  selectedRequest: NetworkRequest;
   getStatusColor: (status: number) => string;
 };
 
 export const HeadersTab = ({
   selectedRequest,
-  networkEntries,
   getStatusColor,
 }: HeadersTabProps) => {
   return (
     <ScrollArea className="h-full min-h-0">
       <div className="p-4 space-y-4">
+        <CopyAsCurlButton selectedRequest={selectedRequest} />
         <div>
           <h4 className="text-sm font-medium text-gray-300 mb-2">General</h4>
           <div className="space-y-1 text-sm">
@@ -62,8 +52,7 @@ export const HeadersTab = ({
           </h4>
           <div className="space-y-1 text-sm font-mono">
             {(() => {
-              const entry = networkEntries.get(selectedRequest.id);
-              const responseHeaders = entry?.response?.headers;
+              const responseHeaders = selectedRequest.headers;
               if (responseHeaders && Object.keys(responseHeaders).length > 0) {
                 return Object.entries(responseHeaders).map(([key, value]) => (
                   <div key={key} className="flex">
@@ -90,8 +79,7 @@ export const HeadersTab = ({
           </h4>
           <div className="space-y-1 text-sm font-mono">
             {(() => {
-              const entry = networkEntries.get(selectedRequest.id);
-              const requestHeaders = entry?.request?.headers;
+              const requestHeaders = selectedRequest.headers;
               if (requestHeaders && Object.keys(requestHeaders).length > 0) {
                 return Object.entries(requestHeaders).map(([key, value]) => (
                   <div key={key} className="flex">

--- a/packages/network-activity-plugin/src/ui/tabs/RequestTab.tsx
+++ b/packages/network-activity-plugin/src/ui/tabs/RequestTab.tsx
@@ -1,14 +1,10 @@
+import * as React from 'react';
 import { ScrollArea } from '../components/ScrollArea';
 import { JsonTree } from '../components/JsonTree';
+import { NetworkRequest } from '../components/RequestList';
 
 export type RequestTabProps = {
-  selectedRequest: {
-    method: string;
-    requestBody?: {
-      type: string;
-      data: string;
-    };
-  };
+  selectedRequest: NetworkRequest;
 };
 
 export const RequestTab = ({ selectedRequest }: RequestTabProps) => {

--- a/packages/network-activity-plugin/src/ui/tabs/RequestTab.tsx
+++ b/packages/network-activity-plugin/src/ui/tabs/RequestTab.tsx
@@ -15,7 +15,7 @@ export const RequestTab = ({ selectedRequest }: RequestTabProps) => {
 
     if (type === 'application/json') {
       try {
-        const jsonData = JSON.parse(data);
+        const jsonData = JSON.parse(data as string);
         return (
           <div className="bg-gray-800 p-3 rounded border border-gray-700">
             <JsonTree data={jsonData} />
@@ -25,7 +25,7 @@ export const RequestTab = ({ selectedRequest }: RequestTabProps) => {
         // Fallback to pre tag if JSON parsing fails
         return (
           <pre className="text-sm font-mono text-gray-300 whitespace-pre-wrap bg-gray-800 p-3 rounded border border-gray-700 overflow-x-auto">
-            {data}
+            {String(data)}
           </pre>
         );
       }
@@ -34,7 +34,7 @@ export const RequestTab = ({ selectedRequest }: RequestTabProps) => {
     // For non-JSON content types, use the existing pre tag
     return (
       <pre className="text-sm font-mono text-gray-300 whitespace-pre-wrap bg-gray-800 p-3 rounded border border-gray-700 overflow-x-auto">
-        {data}
+        {String(data)}
       </pre>
     );
   };

--- a/packages/network-activity-plugin/src/ui/types.ts
+++ b/packages/network-activity-plugin/src/ui/types.ts
@@ -5,6 +5,7 @@ import {
   Initiator,
   ResourceType,
   HttpHeaders,
+  RequestPostData,
 } from '../shared/client';
 
 export type NetworkEntry = {
@@ -12,7 +13,7 @@ export type NetworkEntry = {
   url: string;
   method: string;
   headers: HttpHeaders;
-  postData?: string;
+  postData?: RequestPostData;
   status: 'pending' | 'loading' | 'finished' | 'failed';
   startTime: number;
   endTime?: number;

--- a/packages/network-activity-plugin/src/ui/utils/copyToClipboard.ts
+++ b/packages/network-activity-plugin/src/ui/utils/copyToClipboard.ts
@@ -1,11 +1,3 @@
-export async function copyToClipboard(text: string): Promise<boolean> {
-  try {
-    await navigator.clipboard.writeText(text);
-
-    return true;
-  } catch (error) {
-    console.error('Failed to copy to clipboard:', error);
-
-    return false;
-  }
+export async function copyToClipboard(text: string) {
+  return navigator.clipboard.writeText(text);
 }

--- a/packages/network-activity-plugin/src/ui/utils/copyToClipboard.ts
+++ b/packages/network-activity-plugin/src/ui/utils/copyToClipboard.ts
@@ -1,0 +1,11 @@
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+
+    return true;
+  } catch (error) {
+    console.error('Failed to copy to clipboard:', error);
+
+    return false;
+  }
+}

--- a/packages/network-activity-plugin/src/ui/utils/escapeShellArg.ts
+++ b/packages/network-activity-plugin/src/ui/utils/escapeShellArg.ts
@@ -1,0 +1,12 @@
+// Escapes special characters in shell arguments
+export function escapeShellArg(arg: string): string {
+  if (!arg) return "''";
+  
+  // If the argument contains no special characters, return as is
+  if (/^[a-zA-Z0-9_./:-]+$/.test(arg)) {
+    return arg;
+  }
+  
+  // Replace single quotes with '\'' and wrap in single quotes
+  return `'${arg.replace(/'/g, "'\"'\"'")}'`;
+}

--- a/packages/network-activity-plugin/src/ui/utils/generateCurlCommand.ts
+++ b/packages/network-activity-plugin/src/ui/utils/generateCurlCommand.ts
@@ -1,0 +1,88 @@
+import { escapeShellArg } from './escapeShellArg';
+
+const BASE_TAB_INDENT = 2; // Number of spaces for indentation
+
+// Adds a curl parameter with proper indentation
+function addCurlParam(curlParts: string[], flag: string, value: string): void {
+  curlParts.push(`${flag.padStart(BASE_TAB_INDENT + flag.length)} ${value}`);
+}
+
+// Adds HTTP method to curl command parts
+function addMethodToCurl(curlParts: string[], method: string): void {
+  if (method && method.toUpperCase() !== 'GET') {
+    addCurlParam(curlParts, '-X', method.toUpperCase());
+  }
+}
+
+// Adds headers to curl command parts
+function addHeadersToCurl(curlParts: string[], headers: Record<string, string>): void {
+  Object.entries(headers).forEach(([key, value]) => {
+    if (key && value) {
+      addCurlParam(curlParts, '-H', escapeShellArg(`${key}: ${value}`));
+    }
+  });
+}
+
+// Determines if method should include request body
+function shouldIncludeBody(method: string): boolean {
+  return ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method.toUpperCase());
+}
+
+// Gets content type from headers (case-insensitive)
+function getContentType(headers: Record<string, string>): string {
+  return headers['content-type'] || headers['Content-Type'] || '';
+}
+
+// Formats JSON data with proper indentation
+function formatJsonData(postData: string): string {
+  try {
+    const jsonString = JSON.stringify(JSON.parse(postData), null, BASE_TAB_INDENT * 4);
+    
+    return jsonString.replace(/}$/, '}'.padStart(BASE_TAB_INDENT * 4 - 1));
+  } catch {
+    return postData;
+  }
+}
+
+// Adds request body to curl command parts
+function addBodyToCurl(curlParts: string[], postData: string, headers: Record<string, string>): void {
+  const contentType = getContentType(headers);
+  
+  if (contentType.includes('application/json')) {
+    const formattedJson = formatJsonData(postData);
+    
+    addCurlParam(curlParts, '-d', escapeShellArg(formattedJson));
+
+    return;
+  }
+  
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    addCurlParam(curlParts, '-d', escapeShellArg(postData));
+    
+    return;
+  }
+  
+  // For other content types, use --data-raw
+  addCurlParam(curlParts, '--data-raw', escapeShellArg(postData));
+}
+
+// Generates a cURL command from network request data
+export function generateCurlCommand(request: {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  postData?: string;
+}): string {
+  const { method, url, headers = {}, postData } = request;
+  
+  const curlParts: string[] = [`curl ${escapeShellArg(url)}`];
+  
+  addMethodToCurl(curlParts, method);
+  addHeadersToCurl(curlParts, headers);
+  
+  if (postData && shouldIncludeBody(method)) {
+    addBodyToCurl(curlParts, postData, headers);
+  }
+  
+  return curlParts.join(' \\\n');
+}

--- a/packages/network-activity-plugin/src/ui/utils/generateCurlCommand.ts
+++ b/packages/network-activity-plugin/src/ui/utils/generateCurlCommand.ts
@@ -1,86 +1,86 @@
+import { ReactNativeFormData, RequestPostData } from '../../shared/client';
 import { escapeShellArg } from './escapeShellArg';
+import { getHttpHeaderValue } from './getHttpHeaderValue';
 
 const BASE_TAB_INDENT = 2; // Number of spaces for indentation
+
+function stringifyData(postData: RequestPostData): string {
+  try {
+    const jsonString = JSON.stringify(typeof postData === 'string' ? JSON.parse(postData) : postData, null, BASE_TAB_INDENT * 4);
+
+    return jsonString.replace(/([}\]])$/, '$1'.padStart(BASE_TAB_INDENT + 1));
+  } catch {
+    return String(postData);
+  }
+}
+
+function detectPostDataType(postData: RequestPostData) {
+  if (postData === null || postData === undefined) return 'empty';
+  
+  if (typeof postData === 'object' && '_parts' in postData && Array.isArray(postData._parts)) {
+    return 'formdata';
+  }
+
+  return 'unknown';
+}
 
 // Adds a curl parameter with proper indentation
 function addCurlParam(curlParts: string[], flag: string, value: string): void {
   curlParts.push(`${flag.padStart(BASE_TAB_INDENT + flag.length)} ${value}`);
 }
 
-// Adds HTTP method to curl command parts
-function addMethodToCurl(curlParts: string[], method: string): void {
-  if (method && method.toUpperCase() !== 'GET') {
+function addHttpMethodToCurl(curlParts: string[], method: string): void {
+  if (method && isPostRequest(method)) {
     addCurlParam(curlParts, '-X', method.toUpperCase());
   }
 }
 
-// Adds headers to curl command parts
 function addHeadersToCurl(curlParts: string[], headers: Record<string, string>): void {
   Object.entries(headers).forEach(([key, value]) => {
-    if (key && value) {
-      addCurlParam(curlParts, '-H', escapeShellArg(`${key}: ${value}`));
-    }
+    addCurlParam(curlParts, '-H', escapeShellArg(`${key}: ${value}`));
   });
 }
 
-// Determines if method should include request body
-function shouldIncludeBody(method: string): boolean {
-  return ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method.toUpperCase());
+function isPostRequest(method: string): boolean {
+  return method.toLowerCase() !== 'get';
 }
 
-// Gets content type from headers (case-insensitive)
-function getContentType(headers: Record<string, string>): string {
-  return headers['content-type'] || headers['Content-Type'] || '';
-}
+function addBodyToCurl(curlParts: string[], postData: RequestPostData, headers: Record<string, string>): void {
+  const contentType = getHttpHeaderValue(headers, 'content-type');
+  const dataType = detectPostDataType(postData);
 
-// Formats JSON data with proper indentation
-function formatJsonData(postData: string): string {
-  try {
-    const jsonString = JSON.stringify(JSON.parse(postData), null, BASE_TAB_INDENT * 4);
-    
-    return jsonString.replace(/}$/, '}'.padStart(BASE_TAB_INDENT * 4 - 1));
-  } catch {
-    return postData;
+  console.log(postData, contentType, dataType, typeof postData);
+
+  if (dataType === 'empty') {
+    return;
   }
-}
 
-// Adds request body to curl command parts
-function addBodyToCurl(curlParts: string[], postData: string, headers: Record<string, string>): void {
-  const contentType = getContentType(headers);
-  
-  if (contentType.includes('application/json')) {
-    const formattedJson = formatJsonData(postData);
-    
-    addCurlParam(curlParts, '-d', escapeShellArg(formattedJson));
+  // Special case for React Native FormData
+  if (dataType === 'formdata' && contentType?.includes('multipart/form-data')) {
+    const formParts = (postData as ReactNativeFormData)._parts.map(([key, value]) => `${key}=${value}`);
+
+    formParts.forEach(part => addCurlParam(curlParts, '--form', escapeShellArg(part)));
 
     return;
   }
-  
-  if (contentType.includes('application/x-www-form-urlencoded')) {
-    addCurlParam(curlParts, '-d', escapeShellArg(postData));
-    
-    return;
-  }
-  
-  // For other content types, use --data-raw
-  addCurlParam(curlParts, '--data-raw', escapeShellArg(postData));
+
+  addCurlParam(curlParts, '--data-raw', escapeShellArg(stringifyData(postData)));
 }
 
-// Generates a cURL command from network request data
 export function generateCurlCommand(request: {
   method: string;
   url: string;
   headers?: Record<string, string>;
-  postData?: string;
+  postData?: RequestPostData;
 }): string {
   const { method, url, headers = {}, postData } = request;
   
   const curlParts: string[] = [`curl ${escapeShellArg(url)}`];
   
-  addMethodToCurl(curlParts, method);
+  addHttpMethodToCurl(curlParts, method);
   addHeadersToCurl(curlParts, headers);
   
-  if (postData && shouldIncludeBody(method)) {
+  if (postData && isPostRequest(method)) {
     addBodyToCurl(curlParts, postData, headers);
   }
   

--- a/packages/network-activity-plugin/src/ui/views/InspectorView.tsx
+++ b/packages/network-activity-plugin/src/ui/views/InspectorView.tsx
@@ -306,7 +306,6 @@ export const InspectorView = ({ client }: InspectorViewProps) => {
                 >
                   <HeadersTab
                     selectedRequest={selectedRequest}
-                    networkEntries={networkEntries}
                     getStatusColor={getStatusColor}
                   />
                 </TabsContent>


### PR DESCRIPTION
**Main feature:** "Copy as cURL" button in Network Activity Plugin

### What's done:
- ✅ Added button to copy HTTP requests as cURL commands
- ✅ Support for different data types: JSON, FormData, plain strings with react-native specific stuff in mind. I did't handle file uploading requests because they don't make sense outside of react-native. You can generate cURL, but it will not work anyways :)
- ✅ Safe escaping of special characters for running in shell
- ✅ Updated NetworkTestScreen screen to verify FormData functionality

### Why:
Developers can quickly copy any network request from DevTools and run it in terminal for debugging. This is the only reason why we still use Reactotron :)

### How it works:
1. Select a request in Network Activity Plugin
2. Click "Copy as cURL" 
3. Paste in terminal and run

**Example result:**
```bash
curl jsonplaceholder.typicode.com/posts \
  -X POST \
  -H 'content-type: application/json' \
  -H 'x-rozenite-test: true' \
  --data-raw '{
        "title": "title",
        "body": "body",
        "userId": 1
  }'
```

### The problems I found:
- `Request` tab can't properly display `multipart/form-data` right now. It is showing just `[Object object]`, so we need to handle it separately

https://github.com/user-attachments/assets/c49939be-308d-4214-91a2-1ac78e036745

